### PR TITLE
Raise built event on ghost construction

### DIFF
--- a/mod/constructor.lua
+++ b/mod/constructor.lua
@@ -90,6 +90,7 @@ function construct_entities(construction_plan, surface, toolbox)
             }
 
             if modules then ghost.item_requests = modules end
+            script.raise_script_built{entity=ghost} -- raise built event so other mods can detect the new ghost
         end
     end
 end


### PR DESCRIPTION
Some mods (e.g. constructron-continued) rely on this event in order to see that a new ghost was constructed.